### PR TITLE
fixing import of marginalia into inactive connection adapters

### DIFF
--- a/lib/marginalia/railtie.rb
+++ b/lib/marginalia/railtie.rb
@@ -37,29 +37,36 @@ module Marginalia
 
     def self.insert_into_active_record
       if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
-        ActiveRecord::ConnectionAdapters::Mysql2Adapter.module_eval do
-          include Marginalia::ActiveRecordInstrumentation
+        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+          ActiveRecord::ConnectionAdapters::Mysql2Adapter.module_eval do
+            include Marginalia::ActiveRecordInstrumentation
+          end
         end
       end
 
       if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
-        ActiveRecord::ConnectionAdapters::MysqlAdapter.module_eval do
-          include Marginalia::ActiveRecordInstrumentation
+        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::MysqlAdapter)
+          ActiveRecord::ConnectionAdapters::MysqlAdapter.module_eval do
+            include Marginalia::ActiveRecordInstrumentation
+          end
         end
       end
 
       if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
-          include Marginalia::ActiveRecordInstrumentation
+        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
+            include Marginalia::ActiveRecordInstrumentation
+          end
         end
       end
 
       if defined? ActiveRecord::ConnectionAdapters::SQLiteAdapter
-        ActiveRecord::ConnectionAdapters::SQLiteAdapter.module_eval do
-          include Marginalia::ActiveRecordInstrumentation
+        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLiteAdapter)
+          ActiveRecord::ConnectionAdapters::SQLiteAdapter.module_eval do
+            include Marginalia::ActiveRecordInstrumentation
+          end
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
added a check for 

``` ruby
ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters:: adapter_name)
```

should fix issue#2 https://github.com/37signals/marginalia/issues/2
