### PR TITLE
Instruments ActiveRecord::LogSubscriber instead of drivers execute

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -4,20 +4,25 @@ require 'marginalia/comment'
 module Marginalia
   mattr_accessor :application_name
 
-  module ActiveRecordInstrumentation
+  module ActiveRecordLogSubscriberInstrumentation
     def self.included(instrumented_class)
       Marginalia::Comment.components = [:application, :controller, :action]
+
       instrumented_class.class_eval do
-        if defined? :execute
-          alias_method :execute_without_marginalia, :execute
-          alias_method :execute, :execute_with_marginalia
+        if defined? :sql
+          alias_method :sql_without_marginalia, :sql
+          alias_method :sql, :sql_with_marginalia
         end
       end
     end
 
-    def execute_with_marginalia(sql, name = nil)
-      execute_without_marginalia("#{sql} /*#{Marginalia::Comment.to_s}*/", name)
+    # Extends the original method by stamping a comment together with the sql.
+    def sql_with_marginalia(event)
+      if comment = Marginalia::Comment.to_s
+        event.payload[:sql] = "#{event.payload[:sql]} /*#{comment}*/"
+      end
+
+      sql_without_marginalia(event)
     end
   end
-
 end

--- a/lib/marginalia/railtie.rb
+++ b/lib/marginalia/railtie.rb
@@ -29,43 +29,15 @@ module Marginalia
           Marginalia::Comment.update!(self)
           yield
         ensure
-          Marginalia::Comment.clear! 
+          Marginalia::Comment.clear!
         end
         around_filter :record_query_comment
       end
     end
 
     def self.insert_into_active_record
-      if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
-          ActiveRecord::ConnectionAdapters::Mysql2Adapter.module_eval do
-            include Marginalia::ActiveRecordInstrumentation
-          end
-        end
-      end
-
-      if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::MysqlAdapter)
-          ActiveRecord::ConnectionAdapters::MysqlAdapter.module_eval do
-            include Marginalia::ActiveRecordInstrumentation
-          end
-        end
-      end
-
-      if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
-          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
-            include Marginalia::ActiveRecordInstrumentation
-          end
-        end
-      end
-
-      if defined? ActiveRecord::ConnectionAdapters::SQLiteAdapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLiteAdapter)
-          ActiveRecord::ConnectionAdapters::SQLiteAdapter.module_eval do
-            include Marginalia::ActiveRecordInstrumentation
-          end
-        end
+      ActiveRecord::LogSubscriber.module_eval do
+        include Marginalia::ActiveRecordLogSubscriberInstrumentation
       end
     end
   end

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -33,54 +33,67 @@ end
 Marginalia::Railtie.insert
 
 class MarginaliaTest < Test::Unit::TestCase
-  def setup
-    @queries = []
-    ActiveSupport::Notifications.subscribe "sql.active_record" do |*args|
-      @queries << args.last[:sql]
+  class Logger < Array
+    def debug(message)
+      push message
     end
-    @env = Rack::MockRequest.env_for('/')
+
+    def error(message)
+      push message
+    end
+
+    def debug?
+      true
+    end
   end
 
-  def test_query_commenting_on_mysql_driver_with_no_action
+  def setup
+    @old_logger = ActiveRecord::Base.logger
+    @logger     = Logger.new
+    @env        = Rack::MockRequest.env_for('/')
+    ActiveRecord::Base.logger = @logger
+  end
+
+  def test_query_commenting_with_no_action
     ActiveRecord::Base.connection.execute "select id from posts"
-    assert_match %r{select id from posts /\*\*/$}, @queries.first
+    assert_match %r{select id from posts}, @logger.first
   end
 
-  def test_query_commenting_on_mysql_driver_with_action
+  def test_query_commenting_with_action
     PostsController.action(:driver_only).call(@env)
-    assert_match %r{select id from posts /\*application:rails,controller:posts,action:driver_only\*/$}, @queries.first
+    assert_match %r{select id from posts /\*application:rails,controller:posts,action:driver_only\*/}, @logger.first
   end
 
   def test_configuring_application
     Marginalia.application_name = "customapp"
     PostsController.action(:driver_only).call(@env)
 
-    assert_match %r{/\*application:customapp,controller:posts,action:driver_only\*/$}, @queries.first
+    assert_match %r{/\*application:customapp,controller:posts,action:driver_only\*/}, @logger.first
   end
 
   def test_configuring_query_components
     Marginalia::Comment.components = [:controller]
     PostsController.action(:driver_only).call(@env)
 
-    assert_match %r{/\*controller:posts\*/$}, @queries.first
+    assert_match %r{/\*controller:posts\*/}, @logger.first
   end
 
   def test_last_line_component
     Marginalia::Comment.components = [:line]
     PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*line:test/query_comments_test.rb:[0-9]*:in `call'\*/$}, @queries.first
+    assert_match %r{/\*line:test/query_comments_test.rb:[0-9]*:in `call'\*/}, @logger.first
   end
 
   def test_last_line_component_with_lines_to_ignore
     Marginalia::Comment.lines_to_ignore = /foo bar/
     Marginalia::Comment.components = [:line]
     PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*line:.*lib/marginalia/comment.rb:7:in .*?\*/$}, @queries.first
+    assert_match %r{/\*line:.*lib/marginalia/comment.rb:7:in .*?\*/}, @logger.first
   end
 
   def teardown
-    Marginalia.application_name = nil
+    Marginalia.application_name    = nil
     Marginalia::Comment.components = [:application, :controller, :action]
-    ActiveSupport::Notifications.unsubscribe "sql.active_record"
+    ActiveRecord::Base.logger      = @old_logger
   end
 end


### PR DESCRIPTION
Fixes #8

Instead of instrumenting adapters execute method, instruments ActiveRecord::LogSubscriber. Works fine with the sample app https://github.com/fabiokr/marginalia-rails-3.2.3/tree/instrument_log_subscriber
