### PR TITLE
add optional hostname and PID components

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -1,3 +1,5 @@
+require 'socket'
+
 module Marginalia
   module Comment
     mattr_accessor :components, :comment, :lines_to_ignore
@@ -50,6 +52,14 @@ module Marginalia
           end
           last_line
         end
+      end
+
+      def self.hostname
+        @cached_hostname ||= Socket.gethostname
+      end
+
+      def self.pid
+        Process.pid
       end
 
   end

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -75,7 +75,13 @@ class MarginaliaTest < Test::Unit::TestCase
     Marginalia::Comment.lines_to_ignore = /foo bar/
     Marginalia::Comment.components = [:line]
     PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*line:.*lib/marginalia/comment.rb:7:in .*?\*/$}, @queries.first
+    assert_match %r{/\*line:.*lib/marginalia/comment.rb:9:in .*?\*/$}, @queries.first
+  end
+
+  def test_hostname_and_pid
+    Marginalia::Comment.components = [:hostname, :pid]
+    PostsController.action(:driver_only).call(@env)
+    assert_match %r{/\*hostname:#{Socket.gethostname},pid:#{Process.pid}\*/$}, @queries.first
   end
 
   def teardown


### PR DESCRIPTION
We use these in our app so that we can quickly track down what rails process is misbehaving if we see a long running or locked up query.
