### PR TITLE
support for forcing marginalia inclusion

### DIFF
--- a/lib/marginalia/railtie.rb
+++ b/lib/marginalia/railtie.rb
@@ -23,6 +23,10 @@ module Marginalia
       insert_into_action_controller
     end
 
+    def self.config_override?
+      ActiveRecord::Base.connection_config[:use_marginalia]
+    end
+    
     def self.insert_into_action_controller
       ActionController::Base.class_eval do
         def record_query_comment
@@ -37,7 +41,7 @@ module Marginalia
 
     def self.insert_into_active_record
       if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) || config_override?
           ActiveRecord::ConnectionAdapters::Mysql2Adapter.module_eval do
             include Marginalia::ActiveRecordInstrumentation
           end
@@ -45,7 +49,7 @@ module Marginalia
       end
 
       if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::MysqlAdapter)
+        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::MysqlAdapter) || config_override?
           ActiveRecord::ConnectionAdapters::MysqlAdapter.module_eval do
             include Marginalia::ActiveRecordInstrumentation
           end
@@ -54,7 +58,7 @@ module Marginalia
 
       # SQL queries made through PostgreSQLAdapter#exec_delete will not be annotated.
       if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) || config_override?
           ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
             include Marginalia::ActiveRecordInstrumentation
           end
@@ -62,7 +66,7 @@ module Marginalia
       end
 
       if defined? ActiveRecord::ConnectionAdapters::SQLiteAdapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLiteAdapter)
+        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLiteAdapter) || config_override?
           ActiveRecord::ConnectionAdapters::SQLiteAdapter.module_eval do
             include Marginalia::ActiveRecordInstrumentation
           end


### PR DESCRIPTION
Issue: Adding marginalia to systems which use AR plugins to manage replication and sharding results in no comments being appended to queries. 

Context: AR replication libraries like [Octopus|https://github.com/tchandy/octopus] and [DBCharmer|https://github.com/kovyrin/db-charmer] give you Proxy objects back when you call `ActiveRecord::Base.connection.is_a?` - these Proxy objects then delegate to the correct Adapter.

Solution: I initially tried to avoid patching your gem, instead I looked to see whether these libraries were "doing it wrong". I think they're actually doing the right thing - this lead me to decide that giving users the ability to override the decision making is the right thing to do. That is "we're smart enough to know to use a non trivial piece of code like Octopus, we want to be smart enough to tell other pieces of software to do the right thing in these cases". 
