### PR TITLE
actually check to see if the class defines the execute/exec_query methods

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -8,12 +8,12 @@ module Marginalia
     def self.included(instrumented_class)
       Marginalia::Comment.components = [:application, :controller, :action]
       instrumented_class.class_eval do
-        if defined? :execute
+        if instrumented_class.method_defined? :execute
           alias_method :execute_without_marginalia, :execute
           alias_method :execute, :execute_with_marginalia
         end
 
-        if defined? :exec_query
+        if instrumented_class.method_defined? :exec_query
           alias_method :exec_query_without_marginalia, :exec_query
           alias_method :exec_query, :exec_query_with_marginalia
         end


### PR DESCRIPTION
defined?(<symbol>) doesn't seem to do anything.

I prefer this to 37sigals/marginalia#14 if anyone cares about ruby 1.8.7.
