### PR TITLE
Use escaped comment for match

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -22,7 +22,7 @@ module Marginalia
 
     def annotate_sql(sql)
       comment = Marginalia::Comment.construct_comment
-      if comment.present? && !sql.match(comment)
+      if comment.present? && !sql.match(Regexp.escape(comment))
         "#{sql} /*#{comment}*/"
       else
         sql

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -20,6 +20,10 @@ class PostsController < ActionController::Base
   def driver_only
     ActiveRecord::Base.connection.execute "select id from posts"
     render :nothing => true
+  end  
+  def []
+    ActiveRecord::Base.connection.execute "select id from posts"
+    render :nothing => true    
   end
 end
 
@@ -74,6 +78,17 @@ class MarginaliaTest < Test::Unit::TestCase
     # triggers the query.
     assert_match %r{/\*line:test/query_comments_test.rb:[0-9]+:in `driver_only'\*/$}, @queries.first
   end
+
+  def test_last_line_component_escaping
+    Marginalia::Comment.components = [:line]
+    PostsController.action(:[]).call(@env)
+
+    # Because "lines_to_ignore" by default includes "marginalia" and "gem", the
+    # extracted line line will be from the line in this file that actually
+    # triggers the query.
+    assert_match %r{/\*line:test/query_comments_test.rb:[0-9]+:in `\[\]'\*/$}, @queries.first
+  end
+
 
   def test_last_line_component_with_lines_to_ignore
     Marginalia::Comment.lines_to_ignore = /foo bar/


### PR DESCRIPTION
Ruby's match method on string, when passed a string, does not escape things like [], so explicitly escape prior to calling match. Since methods can have method names like [] and []= this means that if you don't escape, you will get 

``` ruby
RegexpError: empty char-class
```
