### PR TITLE
Match 'vendor/' instead of just 'vendor'

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -40,11 +40,11 @@ module Marginalia
       end
 
       def self.action
-        @controller.action_name if @controller.respond_to? :action_name 
+        @controller.action_name if @controller.respond_to? :action_name
       end
 
       def self.line
-        Marginalia::Comment.lines_to_ignore ||= /\.rvm|gem|vendor|marginalia|rbenv/
+        Marginalia::Comment.lines_to_ignore ||= /\.rvm|gem|vendor\/|marginalia|rbenv/
         last_line = caller.detect do |line|
           line !~ Marginalia::Comment.lines_to_ignore
         end


### PR DESCRIPTION
This updates `lines_to_ignore` to look for `vendor/` (which should always match the `vendor` directory), and not just `vendor` (which will result in false positives, like in files called, e.g., `controllers/vendors.rb`). It might be worth considering tightening up the other regexes, too, but this one is the most obvious.
