### PR TITLE
Fix misattributed queries on multithreaded servers

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -6,7 +6,7 @@ module Marginalia
     Marginalia::Comment.components ||= [:application, :controller, :action]
 
     def self.update!(controller = nil)
-      @controller = controller
+      self.marginalia_controller = controller
     end
 
     def self.construct_comment
@@ -22,10 +22,18 @@ module Marginalia
     end
 
     def self.clear!
-      @controller = nil
+      self.marginalia_controller = nil
     end
 
     private
+      def self.marginalia_controller=(controller)
+        Thread.current[:marginalia_controller] = controller
+      end
+
+      def self.marginalia_controller
+        Thread.current[:marginalia_controller]
+      end
+
       def self.application
         if defined?(Rails.application)
           Marginalia.application_name ||= Rails.application.class.name.split("::").first
@@ -37,15 +45,15 @@ module Marginalia
       end
 
       def self.controller
-        @controller.controller_name if @controller.respond_to? :controller_name
+        marginalia_controller.controller_name if marginalia_controller.respond_to? :controller_name
       end
 
       def self.controller_with_namespace
-        @controller.class.name if @controller
+        marginalia_controller.class.name if marginalia_controller
       end
 
       def self.action
-        @controller.action_name if @controller.respond_to? :action_name
+        marginalia_controller.action_name if marginalia_controller.respond_to? :action_name
       end
 
       def self.line
@@ -77,8 +85,8 @@ module Marginalia
       end
 
       def self.request_id
-        if @controller.respond_to?(:request) && @controller.request.respond_to?(:uuid)
-          @controller.request.uuid
+        if marginalia_controller.respond_to?(:request) && marginalia_controller.request.respond_to?(:uuid)
+          marginalia_controller.request.uuid
         end
       end
   end


### PR DESCRIPTION
The controller for the current request is stored in a class instance variable right now. This variable is shared between threads, so in a multithreaded environment queries are attributed to whichever request started most recently.

This patch stores the controller in a thread-local variable instead, so parallel requests in the same process can't interfere with each other.