### PR TITLE
Don't overwrite comment components if they're already set

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -6,7 +6,6 @@ module Marginalia
 
   module ActiveRecordInstrumentation
     def self.included(instrumented_class)
-      Marginalia::Comment.components ||= [:application, :controller, :action]
       instrumented_class.class_eval do
         if instrumented_class.method_defined?(:execute)
           alias_method :execute_without_marginalia, :execute

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -3,6 +3,7 @@ require 'socket'
 module Marginalia
   module Comment
     mattr_accessor :components, :lines_to_ignore
+    Marginalia::Comment.components ||= [:application, :controller, :action]
 
     def self.update!(controller = nil)
       @controller = controller


### PR DESCRIPTION
Small fix. I'm finding that in a Rails 4.1 app (running rails-api) that the Marginalia instrumentation is being lazy loaded by ActiveSupport. This means it runs after I've set the comment components in my initializer, so they get overwritten. Switching the assignment to `||=` stops them being overwritten.

cc @arthurnn 
