### PR TITLE
Add ability to record Rails request ID

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -76,6 +76,11 @@ module Marginalia
         Process.pid
       end
 
+      def self.request_id
+        if @controller.respond_to?(:request) && @controller.request.respond_to?(:uuid)
+          @controller.request.uuid
+        end
+      end
   end
 
 end


### PR DESCRIPTION
~~**Merge after #37 - I branched off that branch to avoid creating conflicts with my own PR**~~ Done

Something I find really useful in Rails is the ability to correlate cross-service requests [using consistent request IDs](http://api.rubyonrails.org/classes/ActionDispatch/RequestId.html). I'd love to have these recorded in query logs as well, so I can correlate DB calls all the way back up to a request hitting the web server at the front.

This PR adds that ability to Marginalia.

cc @arthurnn 
