### PR TITLE
Add new component `controller_with_namespace` (closes #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ default. In addition, implementation is provided for:
   * `:line` (for file and line number calling query). :line supports
     a configuration by setting a regexp in `Marginalia::Comment.lines_to_ignore`
     to exclude parts of the stacktrace from inclusion in the line comment.
+  * `:controller_with_namespace` to include the full classname (including namespace)
+    of the controller.
 
 Pull requests for other included comment components are welcome.
 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -39,6 +39,10 @@ module Marginalia
         @controller.controller_name if @controller.respond_to? :controller_name
       end
 
+      def self.controller_with_namespace
+        @controller.class.name if @controller
+      end
+
       def self.action
         @controller.action_name if @controller.respond_to? :action_name
       end

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -25,6 +25,13 @@ class PostsController < ActionController::Base
   end
 end
 
+module API
+  module V1
+    class PostsController < ::PostsController
+    end
+  end
+end
+
 unless Post.table_exists?
   ActiveRecord::Schema.define do
     create_table "posts", :force => true do |t|
@@ -104,7 +111,12 @@ class MarginaliaTest < Test::Unit::TestCase
     Marginalia::Comment.components = [:hostname, :pid]
     PostsController.action(:driver_only).call(@env)
     assert_match %r{/\*hostname:#{Socket.gethostname},pid:#{Process.pid}\*/$}, @queries.first
+  end
 
+  def test_controller_with_namespace
+    Marginalia::Comment.components = [:controller_with_namespace]
+    API::V1::PostsController.action(:driver_only).call(@env)
+    assert_match %r{/\*controller_with_namespace:API::V1::PostsController}, @queries.first
   end
 
   def teardown


### PR DESCRIPTION
Add new component `controller_with_namespace` to provide a way to get the full controller name including it's namespace to the query comments.

This closes #40
