### PR TITLE
Avoid connecting to the database to instrument active record.

### DIFF
--- a/lib/marginalia/railtie.rb
+++ b/lib/marginalia/railtie.rb
@@ -37,35 +37,27 @@ module Marginalia
 
     def self.insert_into_active_record
       if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
-          ActiveRecord::ConnectionAdapters::Mysql2Adapter.module_eval do
-            include Marginalia::ActiveRecordInstrumentation
-          end
+        ActiveRecord::ConnectionAdapters::Mysql2Adapter.module_eval do
+          include Marginalia::ActiveRecordInstrumentation
         end
       end
 
       if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::MysqlAdapter)
-          ActiveRecord::ConnectionAdapters::MysqlAdapter.module_eval do
-            include Marginalia::ActiveRecordInstrumentation
-          end
+        ActiveRecord::ConnectionAdapters::MysqlAdapter.module_eval do
+          include Marginalia::ActiveRecordInstrumentation
         end
       end
 
       # SQL queries made through PostgreSQLAdapter#exec_delete will not be annotated.
       if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
-          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
-            include Marginalia::ActiveRecordInstrumentation
-          end
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
+          include Marginalia::ActiveRecordInstrumentation
         end
       end
 
       if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
-        if ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
-          ActiveRecord::ConnectionAdapters::SQLite3Adapter.module_eval do
-            include Marginalia::ActiveRecordInstrumentation
-          end
+        ActiveRecord::ConnectionAdapters::SQLite3Adapter.module_eval do
+          include Marginalia::ActiveRecordInstrumentation
         end
       end
     end


### PR DESCRIPTION
cc @arthurnn 
## Problem

It looks like there were two fixes for issue #2.
1. commit 0110a04a192f7474de9c667a9a373a540b58facd tried to fix it, but the check wasn't done right, so needed to get fixed by pull #21.
2. Another fix was pull #6

I dislike the solution in pull #6 since it connects to the database to make the check.  This makes it hard to change the configuration (e.g. with mysql2 the configuration can't be changed after it connects), and it can make processes that don't need to use the database dependant on it being available.
## Solution

I removed the redundant fix which unnecessarily connected to the database.
## Testing

I used to following script to make sure this works as intended

``` ruby
require 'active_record'
require 'action_controller'
require 'marginalia'
RAILS_ROOT = File.expand_path(File.dirname(__FILE__))

ActiveRecord::Base.establish_connection({
  :adapter  => ENV["DRIVER"] || "mysql",
  :host     => "localhost",
  :username => ENV["DB_USERNAME"] || "root",
  :database => "marginalia_test"
})

# notice that establish_connection doesn't actually connect to the database
fail if ActiveRecord::Base.connection_pool.active_connection?

# make sure issue #2 is still fixed
class ActiveRecord::ConnectionAdapters::SQLiteAdapter
end
fail if ActiveRecord::ConnectionAdapters::SQLiteAdapter.method_defined?(:execute)

Marginalia::Railtie.insert

# will fail if a connection was made to the database
fail if ActiveRecord::Base.connection_pool.active_connection?
```
