### PR TITLE
Add ActiveJob component

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ default. In addition, implementation is provided for:
     to exclude parts of the stacktrace from inclusion in the line comment.
   * `:controller_with_namespace` to include the full classname (including namespace)
     of the controller.
+  * `:job` to include the classname of the ActiveJob being performed.
 
 Pull requests for other included comment components are welcome.
 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -9,6 +9,10 @@ module Marginalia
       self.marginalia_controller = controller
     end
 
+    def self.update_job!(job)
+      self.marginalia_job = job
+    end
+
     def self.construct_comment
       ret = ''
       self.components.each do |c|
@@ -25,6 +29,10 @@ module Marginalia
       self.marginalia_controller = nil
     end
 
+    def self.clear_job!
+      self.marginalia_job = nil
+    end
+
     private
       def self.marginalia_controller=(controller)
         Thread.current[:marginalia_controller] = controller
@@ -32,6 +40,14 @@ module Marginalia
 
       def self.marginalia_controller
         Thread.current[:marginalia_controller]
+      end
+
+      def self.marginalia_job=(job)
+        Thread.current[:marginalia_job] = job
+      end
+
+      def self.marginalia_job
+        Thread.current[:marginalia_job]
       end
 
       def self.application
@@ -42,6 +58,10 @@ module Marginalia
         end
 
         Marginalia.application_name
+      end
+
+      def self.job
+        marginalia_job.class.name if marginalia_job
       end
 
       def self.controller


### PR DESCRIPTION
This PR adds an optional `:job` component, which contains the classname of the ActiveJob being performed.

I used a thread local to store the job name. Using a `mattr` variable on `Marginalia::Comment` would allow concurrent jobs to overwrite each other's values.