### PR TITLE
Added rake_task component

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ default. In addition, implementation is provided for:
   * `:controller_with_namespace` to include the full classname (including namespace)
     of the controller.
   * `:job` to include the classname of the ActiveJob being performed.
+  * `:rake_task` to include the name of the Rake task being performed.
+
+For Rake tasks, you also need to add to your Rakefile.
+
+    require 'marginalia/rake'
 
 Pull requests for other included comment components are welcome.
 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -13,6 +13,10 @@ module Marginalia
       self.marginalia_job = job
     end
 
+    def self.update_rake_task!(rake_task)
+      self.marginalia_rake_task = rake_task
+    end
+
     def self.construct_comment
       ret = ''
       self.components.each do |c|
@@ -50,6 +54,14 @@ module Marginalia
         Thread.current[:marginalia_job]
       end
 
+      def self.marginalia_rake_task=(rake_task)
+        Thread.current[:marginalia_rake_task] = rake_task
+      end
+
+      def self.marginalia_rake_task
+        Thread.current[:marginalia_rake_task]
+      end
+
       def self.application
         if defined?(Rails.application)
           Marginalia.application_name ||= Rails.application.class.name.split("::").first
@@ -62,6 +74,10 @@ module Marginalia
 
       def self.job
         marginalia_job.class.name if marginalia_job
+      end
+
+      def self.rake_task
+        marginalia_rake_task
       end
 
       def self.controller

--- a/lib/marginalia/rake.rb
+++ b/lib/marginalia/rake.rb
@@ -1,0 +1,1 @@
+Marginalia::Comment.update_rake_task!(ARGV[0])


### PR DESCRIPTION
Hi, thanks for the awesome gem! :+1:

This adds the task name to rake tasks.  There may be a better way to hook into Rake or parse out the task name. For instance, it won't work for multiple rake tasks in a row - `rake task1 task2`.
