### PR TITLE
Users are not required to require 'marginalia/railtie' explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Patches are welcome for other database adapters.
 
     # Gemfile
     gem 'marginalia'
-    
-    # config/application.rb
-    require 'marginalia/railtie'
-
 
 ### For Rails 2.x:
 


### PR DESCRIPTION
It should be required at the top of marginalia.rb https://github.com/basecamp/marginalia/blob/2b995f80d68411ae081938a121568013d0dd44fa/lib/marginalia.rb#L1