### PR TITLE
Avoiding mysql2 0.4.1 which does not load database adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tmp
 marginalia_test
 Gemfile.lock
+bin/

--- a/marginalia.gemspec
+++ b/marginalia.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "activerecord", ">= 2.3"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "mysql"
-  gem.add_development_dependency "mysql2"
+  gem.add_development_dependency "mysql2", '<= 0.4.0'
   gem.add_development_dependency "pg"
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "minitest"


### PR DESCRIPTION
````
Run options: --seed 9869

# Running:

[ActiveJob] Enqueued PostsJob (Job ID: f905141a-7d7f-47c4-a2fc-2e007f7a9d44) to Inline(default)
[ActiveJob] [PostsJob] [f905141a-7d7f-47c4-a2fc-2e007f7a9d44] Performing PostsJob from Inline(default)
[ActiveJob] [PostsJob] [f905141a-7d7f-47c4-a2fc-2e007f7a9d44] Performed PostsJob from Inline(default) in 10.55ms
............

Finished in 0.028879s, 415.5268 runs/s, 796.4264 assertions/s.

12 runs, 23 assertions, 0 failures, 0 errors, 0 skips
DRIVER=mysql2 ruby -Ilib -Itest test/*_test.rb
/Users/hi/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.4/lib/active_record/connection_adapters/connection_specification.rb:177:in `rescue in spec': Specified 'mysql2' for database adapter, but the gem is not loaded. Add `gem 'mysql2'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord). (Gem::LoadError)
	from /Users/hi/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.4/lib/active_record/connection_adapters/connection_specification.rb:174:in `spec'
	from /Users/hi/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.4/lib/active_record/connection_handling.rb:50:in `establish_connection'
	from test/query_comments_test.rb:50:in `<main>'
rake aborted!
````