### PR TITLE
Add compatibility with rails 5

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -56,6 +56,13 @@ module Marginalia
       exec_query_without_marginalia(annotate_sql(sql), name, binds)
     end
 
+    if ActiveRecord::VERSION::MAJOR >= 5
+      def exec_query_with_marginalia(sql, name = 'SQL', binds = [], options = {})
+        options[:prepare] ||= false
+        exec_query_without_marginalia(annotate_sql(sql), name, binds, options)
+      end
+    end
+
     def exec_delete_with_marginalia(sql, name = 'SQL', binds = [])
       exec_delete_without_marginalia(annotate_sql(sql), name, binds)
     end


### PR DESCRIPTION
I get the following error when using this gem with rails 5.0.0.beta1:

```
/Users/mgrachev/mm/vendor/bundle/gems/marginalia-1.3.0/lib/marginalia.rb:55:in `exec_query_with_marginalia': wrong number of arguments (4 for 1..3) (ArgumentError)
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/connection_adapters/abstract/database_statements.rb:375:in `select_prepared'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/connection_adapters/abstract/database_statements.rb:39:in `select_all'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/querying.rb:39:in `find_by_sql'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/relation.rb:691:in `exec_queries'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/relation.rb:572:in `load'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/relation.rb:252:in `to_a'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/relation/delegation.rb:39:in `map'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/migration.rb:1002:in `block in get_all_versions'
from /Users/mgrachev/mm/vendor/bundle/gems/activesupport-5.0.0.beta1/lib/active_support/deprecation/reporting.rb:34:in `silence'
from /Users/mgrachev/mm/vendor/bundle/gems/activesupport-5.0.0.beta1/lib/active_support/deprecation/instance_delegator.rb:19:in `silence'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/migration.rb:1000:in `get_all_versions'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/migration.rb:1014:in `needs_migration?'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/migration.rb:548:in `load_schema_if_pending!'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/migration.rb:563:in `block in maintain_test_schema!'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/migration.rb:794:in `suppress_messages'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/migration.rb:568:in `method_missing'
from /Users/mgrachev/mm/vendor/bundle/gems/activerecord-5.0.0.beta1/lib/active_record/migration.rb:563:in `maintain_test_schema!'
```

This PR adds compatibility with new version rails and fix this error.