### PR TITLE
Strips out malicious components that include "*/"

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -22,6 +22,7 @@ module Marginalia
         end
       end
       ret.chop!
+      ret.gsub!(/\*\//, "")
       ret
     end
 

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -205,6 +205,12 @@ class MarginaliaTest < MiniTest::Test
     assert_match %r{/\*controller_with_namespace:API::V1::PostsController}, @queries.first
   end
 
+  def test_sql_comment_injection
+    Marginalia.application_name = "a sketchy comment */"
+    ActiveRecord::Base.connection.execute "select id from posts"
+    assert_match %r{select id from posts /\*application:a sketchy comment \*/$}, @queries.first
+  end
+
   if request_id_available?
     def test_request_id
       @env["action_dispatch.request_id"] = "some-uuid"


### PR DESCRIPTION
If there is any untrusted string added as a component, it could include "*/" to inject its own SQL.

```
/* foo:bar */; ... danger zone...; /*
```

This strips out all occurrences of "*/" so nothing can close the comment for us.
