### PR TITLE
fix ruby 2.3 testing (from 2.3 => 2.3.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.1
 
 sudo: false
 


### PR DESCRIPTION
RVM does not detect Ruby 2.3 as a valid Ruby version.
