### PR TITLE
Fix for missing query comment for Model.exists? in Postgres

### DIFF
--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -114,6 +114,12 @@ class MarginaliaTest < MiniTest::Test
     ActiveRecord::Base.connection.unstub(:annotate_sql)
   end
 
+  def test_exists
+    skip if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('3.2')
+    Post.exists?
+    assert_match %r{/\*application:rails\*/$}, @queries.last
+  end
+
   def test_query_commenting_on_mysql_driver_with_no_action
     ActiveRecord::Base.connection.execute "select id from posts"
     assert_match %r{select id from posts /\*application:rails\*/$}, @queries.first


### PR DESCRIPTION
Follow up to #51. Fixes Rails 4.2 and Rails 5.

Here's how it looks when [whitespace is ignored](https://github.com/basecamp/marginalia/compare/master...ankane:exists_fix?expand=1&w=1).

Skipping the new test in 3.1 so tests pass.