### PR TITLE
Add marinalia options for connection spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ default. In addition, implementation is provided for:
   * `:job` to include the classname of the ActiveJob being performed.
   * `:hostname` to include ```Socket.gethostname```.
   * `:pid` to include current process id. 
+
+With ActiveRecord >= 3.2.19:
   * `:db_host` to include the configured database hostname.
   * `:socket` to include the configured database socket.
   * `:database` to include the configured database name.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ default. In addition, implementation is provided for:
   * `:job` to include the classname of the ActiveJob being performed.
   * `:hostname` to include ```Socket.gethostname```.
   * `:pid` to include current process id. 
+  * `:db_host` to include the configured database hostname.
+  * `:socket` to include the configured database socket.
+  * `:database` to include the configured database name.
 
 Pull requests for other included comment components are welcome.
 

--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -40,6 +40,7 @@ module Marginalia
     end
 
     def annotate_sql(sql)
+      Marginalia::Comment.update_adapter!(self)
       comment = Marginalia::Comment.construct_comment
       if comment.present? && !sql.include?(comment)
         "#{sql} /*#{comment}*/"

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -13,6 +13,10 @@ module Marginalia
       self.marginalia_job = job
     end
 
+    def self.update_adapter!(adapter)
+      self.marginalia_adapter = adapter
+    end
+
     def self.construct_comment
       ret = ''
       self.components.each do |c|
@@ -48,6 +52,14 @@ module Marginalia
 
       def self.marginalia_job
         Thread.current[:marginalia_job]
+      end
+
+      def self.marginalia_adapter=(adapter)
+        Thread.current[:marginalia_adapter] = adapter
+      end
+
+      def self.marginalia_adapter
+        Thread.current[:marginalia_adapter]
       end
 
       def self.application
@@ -108,6 +120,29 @@ module Marginalia
         if marginalia_controller.respond_to?(:request) && marginalia_controller.request.respond_to?(:uuid)
           marginalia_controller.request.uuid
         end
+      end
+
+      def self.socket
+        if self.connection_config.present?
+          self.connection_config[:socket]
+        end
+      end
+
+      def self.db_host
+        if self.connection_config.present?
+          self.connection_config[:host]
+        end
+      end
+
+      def self.database
+        if self.connection_config.present?
+          self.connection_config[:database]
+        end
+      end
+
+      def self.connection_config
+        return if marginalia_adapter.pool.nil?
+        marginalia_adapter.pool.spec.config
       end
   end
 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -122,27 +122,29 @@ module Marginalia
         end
       end
 
-      def self.socket
-        if self.connection_config.present?
-          self.connection_config[:socket]
+      if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('3.2.19')
+        def self.socket
+          if self.connection_config.present?
+            self.connection_config[:socket]
+          end
         end
-      end
 
-      def self.db_host
-        if self.connection_config.present?
-          self.connection_config[:host]
+        def self.db_host
+          if self.connection_config.present?
+            self.connection_config[:host]
+          end
         end
-      end
 
-      def self.database
-        if self.connection_config.present?
-          self.connection_config[:database]
+        def self.database
+          if self.connection_config.present?
+            self.connection_config[:database]
+          end
         end
-      end
 
-      def self.connection_config
-        return if marginalia_adapter.pool.nil?
-        marginalia_adapter.pool.spec.config
+        def self.connection_config
+          return if marginalia_adapter.pool.nil?
+          marginalia_adapter.pool.spec.config
+        end
       end
   end
 

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -13,6 +13,10 @@ def active_job_available?
   Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('4.2')
 end
 
+def adapter_pool_available?
+  Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('3.2.19')
+end
+
 require "minitest/autorun"
 require 'mocha/test_unit'
 require 'logger'
@@ -205,26 +209,28 @@ class MarginaliaTest < MiniTest::Test
     assert_match %r{/\*controller_with_namespace:API::V1::PostsController}, @queries.first
   end
 
-  def test_db_host
-    Marginalia::Comment.components = [:db_host]
-    API::V1::PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*db_host:localhost}, @queries.first
-  end
+  if adapter_pool_available?
+    def test_db_host
+      Marginalia::Comment.components = [:db_host]
+      API::V1::PostsController.action(:driver_only).call(@env)
+      assert_match %r{/\*db_host:localhost}, @queries.first
+    end
 
-  def test_database
-    Marginalia::Comment.components = [:database]
-    API::V1::PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*database:marginalia_test}, @queries.first
-  end
+    def test_database
+      Marginalia::Comment.components = [:database]
+      API::V1::PostsController.action(:driver_only).call(@env)
+      assert_match %r{/\*database:marginalia_test}, @queries.first
+    end
 
-  def test_socket
-    # setting socket in configuration would break some connections - mock it instead
-    pool = ActiveRecord::Base.connection_pool
-    pool.spec.stubs(:config).returns({:socket => "marginalia_socket"})
-    Marginalia::Comment.components = [:socket]
-    API::V1::PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*socket:marginalia_socket}, @queries.first
-    pool.spec.unstub(:config)
+    def test_socket
+      # setting socket in configuration would break some connections - mock it instead
+      pool = ActiveRecord::Base.connection_pool
+      pool.spec.stubs(:config).returns({:socket => "marginalia_socket"})
+      Marginalia::Comment.components = [:socket]
+      API::V1::PostsController.action(:driver_only).call(@env)
+      assert_match %r{/\*socket:marginalia_socket}, @queries.first
+      pool.spec.unstub(:config)
+    end
   end
 
   if request_id_available?

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -205,6 +205,28 @@ class MarginaliaTest < MiniTest::Test
     assert_match %r{/\*controller_with_namespace:API::V1::PostsController}, @queries.first
   end
 
+  def test_db_host
+    Marginalia::Comment.components = [:db_host]
+    API::V1::PostsController.action(:driver_only).call(@env)
+    assert_match %r{/\*db_host:localhost}, @queries.first
+  end
+
+  def test_database
+    Marginalia::Comment.components = [:database]
+    API::V1::PostsController.action(:driver_only).call(@env)
+    assert_match %r{/\*database:marginalia_test}, @queries.first
+  end
+
+  def test_socket
+    # setting socket in configuration would break some connections - mock it instead
+    pool = ActiveRecord::Base.connection_handler.connection_pool_list[0]
+    pool.spec.stubs(:config).returns({:socket => "marginalia_socket"})
+    Marginalia::Comment.components = [:socket]
+    API::V1::PostsController.action(:driver_only).call(@env)
+    assert_match %r{/\*socket:marginalia_socket}, @queries.first
+    pool.spec.unstub(:config)
+  end
+
   if request_id_available?
     def test_request_id
       @env["action_dispatch.request_id"] = "some-uuid"

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -219,7 +219,7 @@ class MarginaliaTest < MiniTest::Test
 
   def test_socket
     # setting socket in configuration would break some connections - mock it instead
-    pool = ActiveRecord::Base.connection_handler.connection_pool_list[0]
+    pool = ActiveRecord::Base.connection_pool
     pool.spec.stubs(:config).returns({:socket => "marginalia_socket"})
     Marginalia::Comment.components = [:socket]
     API::V1::PostsController.action(:driver_only).call(@env)


### PR DESCRIPTION
Add :db_host, :socket, :database marginalia for getting information out
of the currently used pool spec. This makes it easier to debug things
like per-model connection pools and switching connections at runtime.