### PR TITLE
Include Sidekiq Instrumentation

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -1,5 +1,6 @@
 require 'marginalia/railtie'
 require 'marginalia/comment'
+require 'marginalia/sidekiq_instrumentation'
 
 module Marginalia
   mattr_accessor :application_name

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -88,6 +88,10 @@ module Marginalia
         marginalia_controller.action_name if marginalia_controller.respond_to? :action_name
       end
 
+      def self.sidekiq_job
+        marginalia_job["class"] if marginalia_job
+      end
+
       def self.line
         Marginalia::Comment.lines_to_ignore ||= /\.rvm|gem|vendor\/|marginalia|rbenv/
         last_line = caller.detect do |line|

--- a/lib/marginalia/sidekiq_instrumentation.rb
+++ b/lib/marginalia/sidekiq_instrumentation.rb
@@ -1,0 +1,25 @@
+module Marginalia
+
+  # Alternative to ActiveJob Instrumentation for Sidekiq.
+  # Apt for Instrumenting Sidekiq with Rails version < 4.2.
+  module SidekiqInstrumentation
+
+    class Middleware
+      def call(worker, msg, queue)
+        Marginalia::Comment.update_job! msg
+        yield
+      ensure
+        Marginalia::Comment.clear_job!
+      end
+    end
+
+    def self.enable!
+      Sidekiq.configure_server do |config|
+        config.server_middleware do |chain|
+          chain.add Marginalia::SidekiqInstrumentation::Middleware
+        end
+      end
+    end
+  end
+
+end

--- a/marginalia.gemspec
+++ b/marginalia.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "mocha"
+  gem.add_development_dependency "sidekiq"
 
   gem.summary = gem.description = %q{Attach comments to your ActiveRecord queries.}
 end


### PR DESCRIPTION
Ideal for Sidekiq instrumentation when ActiveJob is not available, apt for Rails < 4.2.

Can be turned on by configurting an initializer : 

e.g) config/initializers/marginalia.rb
```
Marginalia::Comment.components = [:sidekiq_job]
Marginalia::SidekiqInstrumentation.enable!
```