### PR TITLE
Fail loudly if mysql fails to compile

### DIFF
--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -12,7 +12,8 @@ begin
   if RUBY_VERSION < "2.4"
     installer.install "mysql", ">=0"
   end
-rescue
+rescue StandardError => e
+  puts(e)
   exit(1)
 end
 


### PR DESCRIPTION
If the build process exits with error code 1, it should also provide the
output from the failing build. Otherwise, it's hard to debug the issue
it's running into.