### PR TITLE
Add an option to prepend comments to the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Optionally, you can set the application name shown in the log like so in an init
 For Rails 3 applications, the name will default to your Rails application name.
 For Rails 2 applications, "rails" is used as the default application name.
 
+#### Components
+
 You can also configure the components of the comment that will be appended,
 by setting `Marginalia::Comment.components`. By default, this is set to:
 
@@ -100,7 +102,17 @@ With ActiveRecord >= 3.2.19:
 
 Pull requests for other included comment components are welcome.
 
-## Inline query annotations
+#### Prepend comments
+
+By default marginalia appends the comments at the end of the query. Certain databases, such as MySQL will truncate
+the query text. This is the case for slow query logs and the results of querying some InnoDB internal tables where the
+length of the query is more than 1024 bytes.
+
+In order to not lose the marginalia comments from your logs, you can prepend the comments using this option:
+
+    Marginalia::Comment.prepend_comment = true
+
+#### Inline query annotations
 
 In addition to the request or job-level component-based annotations,
 Marginalia may be used to add inline annotations to specific queries using a

--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -49,12 +49,21 @@ module Marginalia
       Marginalia::Comment.update_adapter!(self)
       comment = Marginalia::Comment.construct_comment
       if comment.present? && !sql.include?(comment)
-        sql = "#{sql} /*#{comment}*/"
+        sql = if Marginalia::Comment.prepend_comment
+          "/*#{comment}*/ #{sql}"
+        else
+          "#{sql} /*#{comment}*/"
+        end
       end
       inline_comment = Marginalia::Comment.construct_inline_comment
       if inline_comment.present? && !sql.include?(inline_comment)
-        sql = "#{sql} /*#{inline_comment}*/"
+        sql = if Marginalia::Comment.prepend_comment
+          "/*#{inline_comment}*/ #{sql}"
+        else
+          "#{sql} /*#{inline_comment}*/"
+        end
       end
+
       sql
     end
 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -2,7 +2,7 @@ require 'socket'
 
 module Marginalia
   module Comment
-    mattr_accessor :components, :lines_to_ignore
+    mattr_accessor :components, :lines_to_ignore, :prepend_comment
     Marginalia::Comment.components ||= [:application, :controller, :action]
 
     def self.update!(controller = nil)

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -348,6 +348,15 @@ class MarginaliaTest < MiniTest::Test
     assert_match %r{select id from posts /\*foo\*/ /\*application:rails\*/$}, @queries.first
   end
 
+  def test_add_comments_to_beginning_of_query
+    Marginalia::Comment.prepend_comment = true
+
+    ActiveRecord::Base.connection.execute "select id from posts"
+    assert_match %r{/\*application:rails\*/ select id from posts$}, @queries.first
+  ensure
+    Marginalia::Comment.prepend_comment = nil
+  end
+
   def teardown
     Marginalia.application_name = nil
     Marginalia::Comment.lines_to_ignore = nil


### PR DESCRIPTION
MySQL's slow query logs and `SHOW FULL PROCESSLIST` unfortunately truncates queries that are over 1024 bytes in length.

Since the marginalia comments are at the end of the query, it happens that we lose them completely when we need them the most.

This PR adds a simple `Marginalia::Comment.prepend_comment` module attribute accessor. When it is set to true, the comments will be prepended to the query.

Fixes https://github.com/basecamp/marginalia/issues/61

cc @arthurnn 