### PR TITLE
Add an API for writing inline annotations that apply to a subset of queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ With ActiveRecord >= 3.2.19:
 
 Pull requests for other included comment components are welcome.
 
+## Inline query annotations
+
+In addition to the request or job-level component-based annotations,
+Marginalia may be used to add inline annotations to specific queries using a
+block-based API.
+
+For example, the following code:
+
+    Marginalia.with_annotation("foo") do
+      Account.where(queenbee_id: 1234567890).first
+    end
+
+will issue this query:
+
+    Account Load (0.3ms)  SELECT `accounts`.* FROM `accounts`
+    WHERE `accounts`.`queenbee_id` = 1234567890
+    LIMIT 1
+    /*application:BCX,controller:project_imports,action:show*/ /*foo*/
+
+Nesting `with_annotation` blocks will concatenate the comment strings.
+
 ## Contributing
 
 Start by bundling and creating the test database:

--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -52,7 +52,7 @@ module Marginalia
         sql = "#{sql} /*#{comment}*/"
       end
       inline_comment = Marginalia::Comment.construct_inline_comment
-      if inline_comment.present? && !sql.include?(inline_comment)
+      if inline_comment.present?
         sql = "#{sql} /*#{inline_comment}*/"
       end
       sql

--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -49,10 +49,13 @@ module Marginalia
       Marginalia::Comment.update_adapter!(self)
       comment = Marginalia::Comment.construct_comment
       if comment.present? && !sql.include?(comment)
-        "#{sql} /*#{comment}*/"
-      else
-        sql
+        sql = "#{sql} /*#{comment}*/"
       end
+      inline_comment = Marginalia::Comment.construct_inline_comment
+      if inline_comment.present? && !sql.include?(inline_comment)
+        sql = "#{sql} /*#{inline_comment}*/"
+      end
+      sql
     end
 
     def execute_with_marginalia(sql, name = nil)
@@ -100,5 +103,12 @@ module Marginalia
     ensure
       Marginalia::Comment.clear!
     end
+  end
+
+  def self.with_annotation(comment, &block)
+    Marginalia::Comment.inline_annotations.push(comment)
+    block.call if block.present?
+  ensure
+    Marginalia::Comment.inline_annotations.pop
   end
 end

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -30,6 +30,11 @@ module Marginalia
       ret
     end
 
+    def self.construct_inline_comment
+      return nil if inline_annotations.none?
+      escape_sql_comment(inline_annotations.join)
+    end
+
     def self.escape_sql_comment(str)
       while str.include?('/*') || str.include?('*/')
         str = str.gsub('/*', '').gsub('*/', '')
@@ -157,6 +162,10 @@ module Marginalia
           return if marginalia_adapter.pool.nil?
           marginalia_adapter.pool.spec.config
         end
+      end
+
+      def self.inline_annotations
+        Thread.current[:marginalia_inline_annotations] ||= []
       end
   end
 

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -283,7 +283,7 @@ class MarginaliaTest < MiniTest::Test
       refute_match %{job:PostsJob}, @queries.last
     end
   end
-  
+
   def test_sidekiq_job
     Marginalia::Comment.components = [:sidekiq_job]
     Marginalia::SidekiqInstrumentation.enable!
@@ -308,6 +308,37 @@ class MarginaliaTest < MiniTest::Test
   def test_bad_comments
     assert_equal Marginalia::Comment.escape_sql_comment('*/; DROP TABLE USERS;/*'), '; DROP TABLE USERS;'
     assert_equal Marginalia::Comment.escape_sql_comment('**//; DROP TABLE USERS;/*'), '; DROP TABLE USERS;'
+  end
+
+  def test_inline_annotations
+    Marginalia.with_annotation("foo") do
+      Post.first
+    end
+    Post.first
+    assert_match %r{/\/\*foo\*\//$}, @queries.first
+    refute_match %r{/\/\*foo\*\//$}, @queries.last
+    # Assert we're not adding an empty comment, either
+    refute_match %r{/\/\*\s*\*\//$}, @queries.last
+  end
+
+  def test_nested_inline_annotations
+    Marginalia.with_annotation("foo") do
+      Marginalia.with_annotation("bar") do
+        Post.first
+      end
+    end
+    assert_match %r{/\*foobar\*/$}, @queries.first
+  end
+
+  def test_bad_inline_annotations
+    Marginalia.with_annotation("*/; DROP TABLE USERS;/*'") do
+      Post.first
+    end
+    Marginalia.with_annotation("**//; DROP TABLE USERS;//**'") do
+      Post.first
+    end
+    assert_match %r{/\*; DROP TABLE USERS;\*/$}, @queries.first
+    assert_match %r{/\*; DROP TABLE USERS;\*/$}, @queries.last
   end
 
   def teardown

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -315,10 +315,10 @@ class MarginaliaTest < MiniTest::Test
       Post.first
     end
     Post.first
-    assert_match %r{/\/\*foo\*\//$}, @queries.first
-    refute_match %r{/\/\*foo\*\//$}, @queries.last
+    assert_match %r{/\*foo\*/$}, @queries.first
+    refute_match %r{/\*foo\*/$}, @queries.last
     # Assert we're not adding an empty comment, either
-    refute_match %r{/\/\*\s*\*\//$}, @queries.last
+    refute_match %r{/\*\s*\*/$}, @queries.last
   end
 
   def test_nested_inline_annotations
@@ -331,10 +331,10 @@ class MarginaliaTest < MiniTest::Test
   end
 
   def test_bad_inline_annotations
-    Marginalia.with_annotation("*/; DROP TABLE USERS;/*'") do
+    Marginalia.with_annotation("*/; DROP TABLE USERS;/*") do
       Post.first
     end
-    Marginalia.with_annotation("**//; DROP TABLE USERS;//**'") do
+    Marginalia.with_annotation("**//; DROP TABLE USERS;//**") do
       Post.first
     end
     assert_match %r{/\*; DROP TABLE USERS;\*/$}, @queries.first


### PR DESCRIPTION
Marginalia's request-level or job-level annotations are great, but in some cases it's valuable to add annotations to a specific subset of queries issued during a request or other context.

Since Marginalia is already hooked into annotating the SQL string passed into the database adapter level, it provides a good chokepoint for that functionality as well.

This patch implements a new API to add that ability. The following code:

```ruby
Marginalia.with_annotation("foo") do
  Account.where(queenbee_id: 1234567890).first
end
```

will issue this query:

    Account Load (0.3ms)  SELECT `accounts`.* FROM `accounts`
    WHERE `accounts`.`queenbee_id` = 1234567890
    LIMIT 1
    /*application:BCX,controller:project_imports,action:show*/ /*foo*/

Any queries issues inside the `with_annotation` block will include the inline comment.

Nesting `with_annotation` blocks will concatenate the comment strings.

```ruby
Marginalia.with_annotation("foo") do
  Marginalia.with_annotation("-bar") do
    Account.where(queenbee_id: 1234567890).first
  end
end
```

yields:

    Account Load (0.3ms)  SELECT `accounts`.* FROM `accounts`
    WHERE `accounts`.`queenbee_id` = 1234567890
    LIMIT 1
    /*application:BCX,controller:project_imports,action:show*/ /*foo-bar*/

/cc @arthurnn 