### PR TITLE
Also de-dupe comments added to queries via with_annotation

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -52,7 +52,7 @@ module Marginalia
         sql = "#{sql} /*#{comment}*/"
       end
       inline_comment = Marginalia::Comment.construct_inline_comment
-      if inline_comment.present?
+      if inline_comment.present? && !sql.include?(inline_comment)
         sql = "#{sql} /*#{inline_comment}*/"
       end
       sql

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -341,6 +341,13 @@ class MarginaliaTest < MiniTest::Test
     assert_match %r{/\*; DROP TABLE USERS;\*/$}, @queries.last
   end
 
+  def test_inline_annotations_are_deduped
+    Marginalia.with_annotation("foo") do
+      ActiveRecord::Base.connection.execute "select id from posts /*foo*/"
+    end
+    assert_match %r{select id from posts /\*foo\*/ /\*application:rails\*/$}, @queries.first
+  end
+
   def teardown
     Marginalia.application_name = nil
     Marginalia::Comment.lines_to_ignore = nil


### PR DESCRIPTION
What's the saying about those who fail to learn from the past being doomed to repeat it? 😳

In https://github.com/basecamp/marginalia/pull/81 I allowed duplicate comments to be added to the SQL query string because I wasn't sure why it was being prevented. (If someone _wants_ to add duplicate comments, why stop them? Etc., etc.)

I fully intended to determine why controller-level comments were de-duping before committing to skipping it in the block-level comments, but I got distracted and then forgot I needed to follow up when it came time to merge #81. I apologize for that.

There's another saying about understanding why a fence was built across a field before tearing it down. From https://github.com/basecamp/marginalia/commit/5d130bf1d77ccf84a4b597ef3d2c53659c5fd058:

> Some adapters (MySQL most notably) call execute from exec_query,
> which results in a double comment being added. Check if a comment is
> already appended before annotating with a duplicate.

@arthurnn, could this fix be merged and a `1.7.1` version of the gem be published? I'm sorry for causing you the extra work. The situation isn't dire — the duplicate comments aren't the end of the world — but it would be great to have this fixed. :bow: