### PR TITLE
Make `controller` component smarter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ rvm:
   - 2.3
   - 2.4
 
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+
 script: "bundle exec rake db:reset test:all"
 
 gemfile:

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ default. In addition, implementation is provided for:
   * `:line` (for file and line number calling query). :line supports
     a configuration by setting a regexp in `Marginalia::Comment.lines_to_ignore`
     to exclude parts of the stacktrace from inclusion in the line comment.
-  * `:controller_with_namespace` to include the full classname (including namespace)
-    of the controller.
   * `:job` to include the classname of the ActiveJob being performed.
   * `:hostname` to include ```Socket.gethostname```.
   * `:pid` to include current process id. 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -90,11 +90,9 @@ module Marginalia
       end
 
       def self.controller
-        marginalia_controller.controller_name if marginalia_controller.respond_to? :controller_name
-      end
-
-      def self.controller_with_namespace
-        marginalia_controller.class.name if marginalia_controller
+        if marginalia_controller.respond_to? :controller_path
+          marginalia_controller.controller_path.split("/").join("::")
+        end
       end
 
       def self.action

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -223,12 +223,12 @@ class MarginaliaTest < MiniTest::Test
 
   def test_controller_with_single_level
     PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*controller:posts}, @queries.first
+    assert_match %r{,?controller:posts,?}, @queries.first
   end
 
   def test_controller_with_namespace
     API::V1::PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*controller:api::v1::posts}, @queries.first
+    assert_match %r{,?controller:api::v1::posts,?}, @queries.first
   end
 
   if adapter_pool_available?

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -221,10 +221,14 @@ class MarginaliaTest < MiniTest::Test
     assert_match %r{/\*hostname:#{Socket.gethostname},pid:#{Process.pid}\*/$}, @queries.first
   end
 
+  def test_controller_with_single_level
+    PostsController.action(:driver_only).call(@env)
+    assert_match %r{/\*controller:posts}, @queries.first
+  end
+
   def test_controller_with_namespace
-    Marginalia::Comment.components = [:controller_with_namespace]
     API::V1::PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*controller_with_namespace:API::V1::PostsController}, @queries.first
+    assert_match %r{/\*controller:api::v1::posts}, @queries.first
   end
 
   if adapter_pool_available?


### PR DESCRIPTION
This introduces a change to combine the `controller` and
`controller_with_namespace` components by making the `controller`
component rely on `controller_path` and manipulate the value that comes
back from that.

The idea for this came from an issue where we wanted the benefits of the
`controller_with_namespace` component but we already have a bunch of
logs with `controller`. Once I looked into how the controller name was
being fetched, I seen we had the chance to consolidate the two
components and remove some of the duplicated functionality.