### PR TITLE
Customizable key-value separator and quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ will issue this query:
 
 Nesting `with_annotation` blocks will concatenate the comment strings.
 
+#### Customizing key-value formatting
+
+To change the default key-value separator (from `,`), set `Marginalia::Comment.key_value_separator`.
+To surround all values with single quotes (`'`) and escape internal quotes as `\'`,
+set `Marginalia::Comment.quote_values = :single`.
+
 ## Contributing
 
 Start by bundling and creating the test database:

--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -114,6 +114,14 @@ module Marginalia
     end
   end
 
+  def self.with_comment_settings(settings)
+    prev = settings.keys.map { |key| [key, Marginalia::Comment.send(key)] }
+    settings.each { |key, value| Marginalia::Comment.send(:"#{key}=", value) }
+    yield
+  ensure
+    prev.each { |(key, value)| Marginalia::Comment.send(:"#{key}=", value) }
+  end
+
   def self.with_annotation(comment, &block)
     Marginalia::Comment.inline_annotations.push(comment)
     block.call if block.present?

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -3,6 +3,17 @@ require 'socket'
 module Marginalia
   module Comment
     mattr_accessor :components, :lines_to_ignore, :prepend_comment
+
+
+    # @return [String] String used for separating keys and values.
+    mattr_accessor :key_value_separator
+    self.key_value_separator = ':'
+
+    # @return [false, :single] If `:single`, surrounds values with single quotes
+    #   (') and escapes internal single quotes as \'.
+    mattr_accessor :quote_values
+    self.quote_values = false
+
     Marginalia::Comment.components ||= [:application, :controller, :action]
 
     def self.update!(controller = nil)
@@ -17,12 +28,19 @@ module Marginalia
       self.marginalia_adapter = adapter
     end
 
+    # @param [String] value
+    # @return [String]
+    def self.quote_value(value)
+      quote_values ? "'#{value.gsub("'", "\\\\'")}'" : value
+    end
+
     def self.construct_comment
       ret = ''
       self.components.each do |c|
         component_value = self.send(c)
         if component_value.present?
-          ret << "#{c.to_s}:#{component_value.to_s},"
+          ret << "#{c}#{key_value_separator}"\
+                 "#{quote_value(component_value.to_s)},"
         end
       end
       ret.chop!

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -366,6 +366,21 @@ class MarginaliaTest < MiniTest::Test
     Marginalia::Comment.prepend_comment = nil
   end
 
+  def test_comment_key_value_separator
+    Marginalia.with_comment_settings(key_value_separator: '=') do
+      ActiveRecord::Base.connection.execute "select id from posts"
+      assert_equal 'select id from posts /*application=rails*/', @queries.first
+    end
+  end
+
+  def test_comment_quote_values_single
+    Marginalia.application_name = "Joe's app"
+    Marginalia.with_comment_settings(quote_values: :single) do
+      ActiveRecord::Base.connection.execute "select id from posts"
+      assert_equal "select id from posts /*application:'Joe\\'s app'*/", @queries.first
+    end
+  end
+
   def teardown
     Marginalia.application_name = nil
     Marginalia::Comment.lines_to_ignore = nil


### PR DESCRIPTION
This is to make it easier to parse these comments from logs.