### PR TITLE
Fix for rails 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ["2.6", "2.7", "3.0"]
-        rails-version: ["5.2.0", "6.0.0"]
+        rails-version: ["5.2.0", "6.0.0", "6.1.0"]
         exclude:
           # Rails 5.2 does not support Ruby 3.0
           - {ruby-version: "3.0", rails-version: "5.2.0"}

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-rails_version = ENV["RAILS_VERSION"] || "6.0.0"
+rails_version = ENV["RAILS_VERSION"] || "6.1.0"
 if rails_version == "main"
   gem "rails", github: "rails/rails"
 else

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This gem was created at 37signals. You can read more about how we use it [on
 our blog](http://37signals.com/svn/posts/3130-tech-note-mysql-query-comments-in-rails).
 
 This has been tested and used in production with the mysql2 and pg gems, and is
-tested on Rails 5.2 through 6.0, and Ruby 2.6 through 3.0. It is also tested
+tested on Rails 5.2 through 6.1, and Ruby 2.6 through 3.0. It is also tested
 for sqlite3.
 
 Rails version support will follow supported versions in the [Ruby on Rails maintenance policy](https://guides.rubyonrails.org/maintenance_policy.html)

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -162,9 +162,17 @@ module Marginalia
         end
       end
 
-      def self.connection_config
-        return if marginalia_adapter.pool.nil?
-        marginalia_adapter.pool.spec.config
+      if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('6.1')
+        def self.connection_config
+          return if marginalia_adapter.pool.nil?
+          marginalia_adapter.pool.spec.config
+        end
+      else
+        def self.connection_config
+          # `pool` might be a NullPool which has no db_config
+          return unless marginalia_adapter.pool.respond_to?(:db_config)
+          marginalia_adapter.pool.db_config.configuration_hash
+        end
       end
 
       def self.inline_annotations

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -123,7 +123,7 @@ module Marginalia
           else
             ""
           end
-          if last_line.starts_with? root
+          if last_line.start_with? root
             last_line = last_line[root.length..-1]
           end
           last_line

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -5,6 +5,10 @@ def using_rails_api?
   ENV["TEST_RAILS_API"] == true
 end
 
+def pool_db_config?
+  Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('6.1')
+end
+
 require "minitest/autorun"
 require "mocha/minitest"
 require 'logger'
@@ -230,14 +234,26 @@ class MarginaliaTest < MiniTest::Test
     assert_match %r{/\*database:marginalia_test}, @queries.first
   end
 
-  def test_socket
-    # setting socket in configuration would break some connections - mock it instead
-    pool = ActiveRecord::Base.connection_pool
-    pool.spec.stubs(:config).returns({:socket => "marginalia_socket"})
-    Marginalia::Comment.components = [:socket]
-    API::V1::PostsController.action(:driver_only).call(@env)
-    assert_match %r{/\*socket:marginalia_socket}, @queries.first
-    pool.spec.unstub(:config)
+  if pool_db_config?
+    def test_socket
+      # setting socket in configuration would break some connections - mock it instead
+      pool = ActiveRecord::Base.connection_pool
+      pool.db_config.stubs(:configuration_hash).returns({:socket => "marginalia_socket"})
+      Marginalia::Comment.components = [:socket]
+      API::V1::PostsController.action(:driver_only).call(@env)
+      assert_match %r{/\*socket:marginalia_socket}, @queries.first
+      pool.db_config.unstub(:configuration_hash)
+    end
+  else
+    def test_socket
+      # setting socket in configuration would break some connections - mock it instead
+      pool = ActiveRecord::Base.connection_pool
+      pool.spec.stubs(:config).returns({:socket => "marginalia_socket"})
+      Marginalia::Comment.components = [:socket]
+      API::V1::PostsController.action(:driver_only).call(@env)
+      assert_match %r{/\*socket:marginalia_socket}, @queries.first
+      pool.spec.unstub(:config)
+    end
   end
 
   def test_request_id

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -101,6 +101,9 @@ Marginalia::Railtie.insert
 
 class MarginaliaTest < MiniTest::Test
   def setup
+    # Touch the model to avoid spurious schema queries
+    Post.first
+
     @queries = []
     ActiveSupport::Notifications.subscribe "sql.active_record" do |*args|
       @queries << args.last[:sql]


### PR DESCRIPTION
Rails 6.1 now returns an instance of `NullPool` instead of `nil` in response to `Connection#pool` at times, and `NullPool` does not have `#spec` so this method blows up. Instead of testing for a `nil` pool, test if the pool responds to `#spec` which should cope with both `nil` and `NullPool` instances with full backwards compatibility.