### PR TITLE
Use `frozen_string_literal: true` to avoid unnecessary string allocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ rvm:
   - 2.3
   - 2.4
 
+services:
+  - mysql
+  - postgresql
+
 script: "bundle exec rake db:reset test:all"
 
 gemfile:

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'socket'
 
 module Marginalia
@@ -18,11 +20,11 @@ module Marginalia
     end
 
     def self.construct_comment
-      ret = ''
+      ret = String.new
       self.components.each do |c|
         component_value = self.send(c)
         if component_value.present?
-          ret << "#{c.to_s}:#{component_value.to_s},"
+          ret << "#{c}:#{component_value},"
         end
       end
       ret.chop!


### PR DESCRIPTION
## Problem

I noticed the string allocations from the [`str.include?` calls in escape_sql_comment](https://github.com/basecamp/marginalia/blob/v1.8.0/lib/marginalia/comment.rb#L39) in a stackprof object profile.  These are unnecessary to allocate on each call since they aren't modified.

## Solution

Use `# frozen_string_literal: true` so that it doesn't allocate these strings on each call.