### PR TITLE
Fix error when Sidekiq used as ActiveJob adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 sudo: false
 
+services:
+  - mysql
+  - postgresql
+
 rvm:
   - 2.2
   - 2.3

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -102,7 +102,7 @@ module Marginalia
       end
 
       def self.sidekiq_job
-        marginalia_job["class"] if marginalia_job
+        marginalia_job["class"] if marginalia_job && marginalia_job.respond_to?(:[])
       end
 
       def self.line

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -282,6 +282,15 @@ class MarginaliaTest < MiniTest::Test
       Post.first
       refute_match %{job:PostsJob}, @queries.last
     end
+
+    def test_active_job_with_sidekiq
+      Marginalia::Comment.components = [:job, :sidekiq_job]
+      PostsJob.perform_later
+      assert_match %{job:PostsJob}, @queries.first
+
+      Post.first
+      refute_match %{job:PostsJob}, @queries.last
+    end
   end
 
   def test_sidekiq_job


### PR DESCRIPTION
Sidekiq provides ActiveJob adapter. Processing ActiveJob jobs with sidekiq causes marginalia error if  `:sidekiq_job` component is enabled.
```
2019-11-29T04:43:44.151Z 24524 TID-gre7wce3k WARN: NoMethodError: undefined method `[]' for #<ActionMailer::DeliveryJob:0x0000560294a16ca0>
2019-11-29T04:43:44.152Z 24524 TID-gre7wce3k WARN: /home/johndoe/.rvm/gems/ruby-2.5.5@foobar/gems/marginalia-1.8.0/lib/marginalia/comment.rb:106:in `sidekiq_job'
/home/johndoe/.rvm/gems/ruby-2.5.5@foobar/gems/marginalia-1.8.0/lib/marginalia/comment.rb:23:in `block in construct_comment'
/home/johndoe/.rvm/gems/ruby-2.5.5@foobar/gems/marginalia-1.8.0/lib/marginalia/comment.rb:22:in `each'
/home/johndoe/.rvm/gems/ruby-2.5.5@foobar/gems/marginalia-1.8.0/lib/marginalia/comment.rb:22:in `construct_comment'
/home/johndoe/.rvm/gems/ruby-2.5.5@foobar/gems/marginalia-1.8.0/lib/marginalia.rb:50:in `annotate_sql'
/home/johndoe/.rvm/gems/ruby-2.5.5@foobar/gems/marginalia-1.8.0/lib/marginalia.rb:71:in `execute_with_marginalia'
```
This PR fixes the error