### PR TITLE
delegate kwargs to eliminate warnings on Ruby 2.7

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -76,9 +76,9 @@ module Marginalia
     end
 
     if ActiveRecord::VERSION::MAJOR >= 5
-      def exec_query_with_marginalia(sql, name = 'SQL', binds = [], options = {})
+      def exec_query_with_marginalia(sql, name = 'SQL', binds = [], **options)
         options[:prepare] ||= false
-        exec_query_without_marginalia(annotate_sql(sql), name, binds, options)
+        exec_query_without_marginalia(annotate_sql(sql), name, binds, **options)
       end
     end
 


### PR DESCRIPTION
The method signature for `exec_query` in Rails uses kwargs, so we need to delegate kwargs (not a hash).

https://github.com/rails/rails/blob/fc4ef77d47c0aff1f3477f42261c1b11e2afecfc/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb#L53