### PR TITLE
Add component to comment with the database role

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -162,6 +162,11 @@ module Marginalia
         end
       end
 
+      def self.db_role
+        return if marginalia_adapter.pool.nil?
+        ActiveRecord::Base.current_role
+      end
+
       if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('6.1')
         def self.connection_config
           return if marginalia_adapter.pool.nil?

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -9,6 +9,10 @@ def pool_db_config?
   Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('6.1')
 end
 
+def database_role_available?
+  Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('6.0.0')
+end
+
 require "minitest/autorun"
 require "mocha/minitest"
 require 'logger'
@@ -256,6 +260,14 @@ class MarginaliaTest < MiniTest::Test
       API::V1::PostsController.action(:driver_only).call(@env)
       assert_match %r{/\*socket:marginalia_socket}, @queries.first
       pool.spec.unstub(:config)
+    end
+  end
+
+  if database_role_available?
+    def test_db_role
+      Marginalia::Comment.components = [:db_role]
+      API::V1::PostsController.action(:driver_only).call(@env)
+      assert_match %r{/\*db_role:writing}, @queries.first
     end
   end
 


### PR DESCRIPTION
With multiple databases in Rails 6, it can be difficult to tell from
logging if your database query is being made against the leader or
follower database. This change adds a new component, `db_role`, which
can be used with the database host and name to annotate the query with
the current ActiveRecord role.

~Rubies prior to 2.5 are now EOLed and Rails 6 can't be installed on Ruby 2.4,
so I've swapped out Rubies 2.2-2.4 for 2.5 and 2.6 in the build matrix.~

Close #102

~This change requires #105 to fix an unrelated failing test case.~