### PR TITLE
Fix false lines_to_ignore match on gems

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -107,8 +107,10 @@ module Marginalia
         marginalia_job["class"] if marginalia_job && marginalia_job.respond_to?(:[])
       end
 
+      DEFAULT_LINES_TO_IGNORE_REGEX = %r{\.rvm|/ruby/gems/|vendor/|marginalia|rbenv|monitor\.rb.*mon_synchronize}
+
       def self.line
-        Marginalia::Comment.lines_to_ignore ||= /\.rvm|gem|vendor\/|marginalia|rbenv|monitor\.rb.*mon_synchronize/
+        Marginalia::Comment.lines_to_ignore ||= DEFAULT_LINES_TO_IGNORE_REGEX
 
         last_line = caller.detect do |line|
           line !~ Marginalia::Comment.lines_to_ignore

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -216,6 +216,16 @@ class MarginaliaTest < MiniTest::Test
     assert_match %r{/\*line:.*lib/marginalia/comment.rb:[0-9]+}, @queries.first
   end
 
+  def test_default_lines_to_ignore_regex
+    line = "/gems/a_gem/lib/a_gem.rb:1:in `some_method'"
+    call_stack = [line] + caller
+
+    assert_match(
+      call_stack.detect { |line| line !~ Marginalia::Comment::DEFAULT_LINES_TO_IGNORE_REGEX },
+      line
+    )
+  end
+
   def test_hostname_and_pid
     Marginalia::Comment.components = [:hostname, :pid]
     PostsController.action(:driver_only).call(@env)


### PR DESCRIPTION
Currently, the default pattern for `Marginalia::Comment.lines_to_ignore` will match any gem (eg even
a local path gem inside a mono-repo) that has `gem` in the name.

This PR changes the default pattern to only ignore installed gems. There are some other changes that
should probably be made to the pattern to be more specific, as for example any gems with `rbenv` or
`marginalia` in their names would also give false matches.