### PR TITLE
master -> main update for Rails in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 rails_version = ENV["RAILS_VERSION"] || "6.0.0"
-if rails_version == "master"
+if rails_version == "main"
   gem "rails", github: "rails/rails"
 else
   gem "rails", "~> #{rails_version}"


### PR DESCRIPTION
I stumbled here trying to set up for local dev / tests:

```
keeran@rumble ~/src/marginalia  [master*] 
> bundle install
Fetching https://github.com/rails/rails.git
fatal: Needed a single revision
Git error: command `git rev-parse --verify master` in directory /Users/keeran/src/marginalia has failed.
Revision master does not exist in the repository https://github.com/rails/rails.git. Maybe you misspelled it?
If this error persists you could try removing the cache directory
'/Users/keeran/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32'
```

This change allowed me to progress 👍 