### PR TITLE
Option to cache comment construction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,8 @@ gem 'pg', '~> 0.15'
 gem 'sqlite3', '~> 1.3.6'
 
 rails = case version
-when "master"
-  {:github => "rails/rails"}
+when "main"
+  {:github => "rails/rails", :branch => 'main'}
 else
   "~> #{version}"
 end

--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@ This helps when searching log files for queries, and seeing where slow queries c
 
 For example, once enabled, your logs will look like:
 
-    Account Load (0.3ms)  SELECT `accounts`.* FROM `accounts` 
-    WHERE `accounts`.`queenbee_id` = 1234567890 
-    LIMIT 1 
+    Account Load (0.3ms)  SELECT `accounts`.* FROM `accounts`
+    WHERE `accounts`.`queenbee_id` = 1234567890
+    LIMIT 1
     /*application:BCX,controller:project_imports,action:show*/
 
-You can also use these query comments along with a tool like [pt-query-digest](http://www.percona.com/doc/percona-toolkit/2.1/pt-query-digest.html#query-reviews) 
+You can also use these query comments along with a tool like [pt-query-digest](http://www.percona.com/doc/percona-toolkit/2.1/pt-query-digest.html#query-reviews)
 to automate identification of controllers and actions that are hotspots for slow queries.
 
 This gem was created at 37signals. You can read more about how we use it [on
 our blog](http://37signals.com/svn/posts/3130-tech-note-mysql-query-comments-in-rails).
 
-This has been tested and used in production with both the mysql and mysql2 gems, 
+This has been tested and used in production with both the mysql and mysql2 gems,
 tested on Rails 2.3.5 through 4.1.x. It has also been tested for sqlite3 and postgres.
 
-Patches are welcome for other database adapters. 
+Patches are welcome for other database adapters.
 
 ## Installation
 
@@ -40,7 +40,7 @@ Or, if your prefer using `config.gem`, you can use:
 
 Finally, if bundled, you'll need to manually run the initialization step in an
 initializer, e.g.:
-    
+
     # Gemfile
     gem 'marginalia', :require => false
 
@@ -93,7 +93,7 @@ default. In addition, implementation is provided for:
     of the controller.
   * `:job` to include the classname of the ActiveJob being performed.
   * `:hostname` to include ```Socket.gethostname```.
-  * `:pid` to include current process id. 
+  * `:pid` to include current process id.
 
 With ActiveRecord >= 3.2.19:
   * `:db_host` to include the configured database hostname.
@@ -132,6 +132,18 @@ will issue this query:
     /*application:BCX,controller:project_imports,action:show*/ /*foo*/
 
 Nesting `with_annotation` blocks will concatenate the comment strings.
+
+#### Caching
+
+In high-traffic scenarios where many queries are executed within a single request cycle, it can be useful to cache the query comment in order to reduce some memory overhead. When enabled, the first comment generated will be re-used for the duration of the request / job execution.
+
+You can enable this feature as follows:
+
+    Marginalia::Comment.cache_comment = true
+
+If you need to reset the cache at any point during a request, use the following:
+
+    Marginalia::Comment.clear_comment_cache!
 
 ## Contributing
 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -4,14 +4,17 @@ require 'socket'
 
 module Marginalia
   module Comment
-    mattr_accessor :components, :lines_to_ignore, :prepend_comment
+    mattr_accessor :components, :lines_to_ignore, :prepend_comment, :cache_comment
     Marginalia::Comment.components ||= [:application, :controller, :action]
+    Marginalia::Comment.cache_comment = false
 
     def self.update!(controller = nil)
+      self.cached_comment = nil if cache_comment
       self.marginalia_controller = controller
     end
 
     def self.update_job!(job)
+      self.cached_comment = nil if cache_comment
       self.marginalia_job = job
     end
 
@@ -20,6 +23,7 @@ module Marginalia
     end
 
     def self.construct_comment
+      return self.cached_comment if cache_comment && !self.cached_comment.nil?
       ret = String.new
       self.components.each do |c|
         component_value = self.send(c)
@@ -29,6 +33,7 @@ module Marginalia
       end
       ret.chop!
       ret = self.escape_sql_comment(ret)
+      self.cached_comment = ret if cache_comment
       ret
     end
 
@@ -45,14 +50,24 @@ module Marginalia
     end
 
     def self.clear!
+      self.cached_comment = nil if cache_comment
       self.marginalia_controller = nil
     end
 
     def self.clear_job!
+      self.cached_comment = nil if cache_comment
       self.marginalia_job = nil
     end
 
     private
+      def self.cached_comment=(comment)
+        Thread.current[:marginalia_cached_comment] = comment
+      end
+
+      def self.cached_comment
+        Thread.current[:marginalia_cached_comment]
+      end
+
       def self.marginalia_controller=(controller)
         Thread.current[:marginalia_controller] = controller
       end

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -9,12 +9,12 @@ module Marginalia
     Marginalia::Comment.cache_comment = false
 
     def self.update!(controller = nil)
-      self.cached_comment = nil if self.cache_comment
+      self.cached_comment = nil
       self.marginalia_controller = controller
     end
 
     def self.update_job!(job)
-      self.cached_comment = nil if self.cache_comment
+      self.cached_comment = nil
       self.marginalia_job = job
     end
 
@@ -54,12 +54,12 @@ module Marginalia
     end
 
     def self.clear!
-      self.cached_comment = nil if self.cache_comment
+      self.cached_comment = nil
       self.marginalia_controller = nil
     end
 
     def self.clear_job!
-      self.cached_comment = nil if self.cache_comment
+      self.cached_comment = nil
       self.marginalia_job = nil
     end
 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -9,12 +9,12 @@ module Marginalia
     Marginalia::Comment.cache_comment = false
 
     def self.update!(controller = nil)
-      self.cached_comment = nil if cache_comment
+      self.cached_comment = nil if self.cache_comment
       self.marginalia_controller = controller
     end
 
     def self.update_job!(job)
-      self.cached_comment = nil if cache_comment
+      self.cached_comment = nil if self.cache_comment
       self.marginalia_job = job
     end
 
@@ -23,7 +23,7 @@ module Marginalia
     end
 
     def self.construct_comment
-      return self.cached_comment if cache_comment && !self.cached_comment.nil?
+      return self.cached_comment if self.cache_comment && !self.cached_comment.nil?
       ret = String.new
       self.components.each do |c|
         component_value = self.send(c)
@@ -33,7 +33,7 @@ module Marginalia
       end
       ret.chop!
       ret = self.escape_sql_comment(ret)
-      self.cached_comment = ret if cache_comment
+      self.cached_comment = ret if self.cache_comment
       ret
     end
 
@@ -54,12 +54,12 @@ module Marginalia
     end
 
     def self.clear!
-      self.cached_comment = nil if cache_comment
+      self.cached_comment = nil if self.cache_comment
       self.marginalia_controller = nil
     end
 
     def self.clear_job!
-      self.cached_comment = nil if cache_comment
+      self.cached_comment = nil if self.cache_comment
       self.marginalia_job = nil
     end
 

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -49,6 +49,10 @@ module Marginalia
       str
     end
 
+    def self.clear_comment_cache!
+      self.cached_comment = nil
+    end
+
     def self.clear!
       self.cached_comment = nil if cache_comment
       self.marginalia_controller = nil

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -381,36 +381,38 @@ class MarginaliaTest < MiniTest::Test
   def test_only_builds_comment_string_once_if_cached
     Marginalia::Comment.cache_comment = true
     String.expects(:new).once.returns("")
-    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    assert_equal "application:rails", Marginalia::Comment.construct_comment
     String.expects(:new).never
-    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    assert_equal "application:rails", Marginalia::Comment.construct_comment
   ensure
+    Marginalia::Comment.clear_comment_cache!
     Marginalia::Comment.cache_comment = false
-    Marginalia::Comment.clear!
     String.unstub(:new)
   end
 
   def test_resets_cache_on_update
     Marginalia::Comment.cache_comment = true
     String.expects(:new).twice.returns("")
-    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    assert_equal "application:rails", Marginalia::Comment.construct_comment
     Marginalia::Comment.update!
-    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    String.expects(:new).once.returns("")
+    assert_equal "application:rails", Marginalia::Comment.construct_comment
   ensure
+    Marginalia::Comment.clear_comment_cache!
     Marginalia::Comment.cache_comment = false
-    Marginalia::Comment.clear!
     String.unstub(:new)
   end
 
   def test_resets_cache_on_clear
     Marginalia::Comment.cache_comment = true
-    String.expects(:new).twice.returns("")
-    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    String.expects(:new).once.returns("")
+    assert_equal "application:rails", Marginalia::Comment.construct_comment
     Marginalia::Comment.clear!
-    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    String.expects(:new).once.returns("")
+    assert_equal "application:rails", Marginalia::Comment.construct_comment
   ensure
+    Marginalia::Comment.clear_comment_cache!
     Marginalia::Comment.cache_comment = false
-    Marginalia::Comment.clear!
     String.unstub(:new)
   end
 

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -386,6 +386,31 @@ class MarginaliaTest < MiniTest::Test
     assert_equal Marginalia::Comment.construct_comment, "application:rails"
   ensure
     Marginalia::Comment.cache_comment = false
+    Marginalia::Comment.clear!
+    String.unstub(:new)
+  end
+
+  def test_resets_cache_on_update
+    Marginalia::Comment.cache_comment = true
+    String.expects(:new).twice.returns("")
+    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    Marginalia::Comment.update!
+    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+  ensure
+    Marginalia::Comment.cache_comment = false
+    Marginalia::Comment.clear!
+    String.unstub(:new)
+  end
+
+  def test_resets_cache_on_clear
+    Marginalia::Comment.cache_comment = true
+    String.expects(:new).twice.returns("")
+    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    Marginalia::Comment.clear!
+    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+  ensure
+    Marginalia::Comment.cache_comment = false
+    Marginalia::Comment.clear!
     String.unstub(:new)
   end
 

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -380,7 +380,6 @@ class MarginaliaTest < MiniTest::Test
 
   def test_only_builds_comment_string_once_if_cached
     Marginalia::Comment.cache_comment = true
-    String.expects(:new).once.returns("")
     assert_equal "application:rails", Marginalia::Comment.construct_comment
     String.expects(:new).never
     assert_equal "application:rails", Marginalia::Comment.construct_comment
@@ -392,7 +391,6 @@ class MarginaliaTest < MiniTest::Test
 
   def test_resets_cache_on_update
     Marginalia::Comment.cache_comment = true
-    String.expects(:new).twice.returns("")
     assert_equal "application:rails", Marginalia::Comment.construct_comment
     Marginalia::Comment.update!
     String.expects(:new).once.returns("")
@@ -405,7 +403,6 @@ class MarginaliaTest < MiniTest::Test
 
   def test_resets_cache_on_clear
     Marginalia::Comment.cache_comment = true
-    String.expects(:new).once.returns("")
     assert_equal "application:rails", Marginalia::Comment.construct_comment
     Marginalia::Comment.clear!
     String.expects(:new).once.returns("")

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -378,6 +378,17 @@ class MarginaliaTest < MiniTest::Test
     Marginalia::Comment.prepend_comment = nil
   end
 
+  def test_only_builds_comment_string_once_if_cached
+    Marginalia::Comment.cache_comment = true
+    String.expects(:new).once.returns("")
+    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+    String.expects(:new).never
+    assert_equal Marginalia::Comment.construct_comment, "application:rails"
+  ensure
+    Marginalia::Comment.cache_comment = false
+    String.unstub(:new)
+  end
+
   def teardown
     Marginalia.application_name = nil
     Marginalia::Comment.lines_to_ignore = nil


### PR DESCRIPTION
This PR introduces the ability to cache the component elements of a query comment to avoid needing to rebuild the same string repeatedly during a request.

I have followed the examples in `Marginalia::Comment` and used `Thread.current` to store the comment string on first execution, if the following is enabled:

```
Marginalia::Comment.cache_comment = true
```

The comment cache is cleared implicitly whenever the following methods are called:

```
Marginalia::Comment.update!
Marginalia::Comment.clear!
Marginalia::Comment.clear_job!
```

If there is a need to reset the cache mid-cycle, I have added a method to do so:

```
Marginalia::Comment.clear_comment_cache!
```

This reduces the memory overhead of building the (usually) same string, in some local tests I have seen allocations reduced by up to 3% for a page generating 80-100 queries.

