### PR TITLE
Handle the recent signature change in Rails edge

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -67,33 +67,38 @@ module Marginalia
       sql
     end
 
-    def execute_with_marginalia(sql, name = nil)
-      execute_without_marginalia(annotate_sql(sql), name)
+    def execute_with_marginalia(sql, *args)
+      execute_without_marginalia(annotate_sql(sql), *args)
     end
+    ruby2_keywords :execute_with_marginalia if respond_to?(:ruby2_keywords, true)
 
-    def exec_query_with_marginalia(sql, name = 'SQL', binds = [])
-      exec_query_without_marginalia(annotate_sql(sql), name, binds)
+    def exec_query_with_marginalia(sql, *args)
+      exec_query_without_marginalia(annotate_sql(sql), *args)
     end
+    ruby2_keywords :exec_query_with_marginalia if respond_to?(:ruby2_keywords, true)
 
     if ActiveRecord::VERSION::MAJOR >= 5
-      def exec_query_with_marginalia(sql, name = 'SQL', binds = [], **options)
+      def exec_query_with_marginalia(sql, *args, **options)
         options[:prepare] ||= false
-        exec_query_without_marginalia(annotate_sql(sql), name, binds, **options)
+        exec_query_without_marginalia(annotate_sql(sql), *args, **options)
       end
     end
 
-    def exec_delete_with_marginalia(sql, name = 'SQL', binds = [])
-      exec_delete_without_marginalia(annotate_sql(sql), name, binds)
+    def exec_delete_with_marginalia(sql, *args)
+      exec_delete_without_marginalia(annotate_sql(sql), *args)
     end
+    ruby2_keywords :exec_delete_with_marginalia if respond_to?(:ruby2_keywords, true)
 
-    def exec_update_with_marginalia(sql, name = 'SQL', binds = [])
-      exec_update_without_marginalia(annotate_sql(sql), name, binds)
+    def exec_update_with_marginalia(sql, *args)
+      exec_update_without_marginalia(annotate_sql(sql), *args)
     end
+    ruby2_keywords :exec_update_with_marginalia if respond_to?(:ruby2_keywords, true)
 
 if ActiveRecord::VERSION::MAJOR >= 5
-    def execute_and_clear_with_marginalia(sql, *args, **kwargs, &block)
-      execute_and_clear_without_marginalia(annotate_sql(sql), *args, **kwargs, &block)
+    def execute_and_clear_with_marginalia(sql, *args, &block)
+      execute_and_clear_without_marginalia(annotate_sql(sql), *args, &block)
     end
+    ruby2_keywords :execute_and_clear_with_marginalia if respond_to?(:ruby2_keywords, true)
  else
    def execute_and_clear_with_marginalia(sql, *args, &block)
      execute_and_clear_without_marginalia(annotate_sql(sql), *args, &block)


### PR DESCRIPTION
In https://github.com/rails/rails/pull/40037 a few methods marginalia decorates have changed signature.

This PR updates marginalia to blindly pass the arguments it doesn't care about. Because of the large range of supported rubies, I use `ruby2_keywords` to simplify things.

I also tried to update CI to test newer Rails versions, but Travis is kind of a nightmare today, and porting this gem to GitHub Actions proved quite tricky.