### PR TITLE
Remove compatibility code for older rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ default. In addition, implementation is provided for:
   * `:job` to include the classname of the ActiveJob being performed.
   * `:hostname` to include ```Socket.gethostname```.
   * `:pid` to include current process id. 
-
-With ActiveRecord >= 3.2.19:
   * `:db_host` to include the configured database hostname.
   * `:socket` to include the configured database socket.
   * `:database` to include the configured database name.

--- a/init.rb
+++ b/init.rb
@@ -1,2 +1,0 @@
-require 'marginalia/railtie'
-Marginalia::Railtie.insert

--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -144,29 +144,27 @@ module Marginalia
         end
       end
 
-      if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('3.2.19')
-        def self.socket
-          if self.connection_config.present?
-            self.connection_config[:socket]
-          end
+      def self.socket
+        if self.connection_config.present?
+          self.connection_config[:socket]
         end
+      end
 
-        def self.db_host
-          if self.connection_config.present?
-            self.connection_config[:host]
-          end
+      def self.db_host
+        if self.connection_config.present?
+          self.connection_config[:host]
         end
+      end
 
-        def self.database
-          if self.connection_config.present?
-            self.connection_config[:database]
-          end
+      def self.database
+        if self.connection_config.present?
+          self.connection_config[:database]
         end
+      end
 
-        def self.connection_config
-          return if marginalia_adapter.pool.nil?
-          marginalia_adapter.pool.spec.config
-        end
+      def self.connection_config
+        return if marginalia_adapter.pool.nil?
+        marginalia_adapter.pool.spec.config
       end
 
       def self.inline_annotations

--- a/lib/marginalia/railtie.rb
+++ b/lib/marginalia/railtie.rb
@@ -1,27 +1,22 @@
 require 'marginalia'
+require 'rails/railtie'
 
 module Marginalia
-  if defined? Rails::Railtie
-    require 'rails/railtie'
+  class Railtie < Rails::Railtie
+    initializer 'marginalia.insert' do
+      ActiveSupport.on_load :active_record do
+        Marginalia::Railtie.insert_into_active_record
+      end
 
-    class Railtie < Rails::Railtie
-      initializer 'marginalia.insert' do
-        ActiveSupport.on_load :active_record do
-          Marginalia::Railtie.insert_into_active_record
-        end
+      ActiveSupport.on_load :action_controller do
+        Marginalia::Railtie.insert_into_action_controller
+      end
 
-        ActiveSupport.on_load :action_controller do
-          Marginalia::Railtie.insert_into_action_controller
-        end
-
-        ActiveSupport.on_load :active_job do
-          Marginalia::Railtie.insert_into_active_job
-        end
+      ActiveSupport.on_load :active_job do
+        Marginalia::Railtie.insert_into_active_job
       end
     end
-  end
 
-  class Railtie
     def self.insert
       insert_into_active_record
       insert_into_action_controller

--- a/lib/marginalia/sidekiq_instrumentation.rb
+++ b/lib/marginalia/sidekiq_instrumentation.rb
@@ -1,7 +1,6 @@
 module Marginalia
 
   # Alternative to ActiveJob Instrumentation for Sidekiq.
-  # Apt for Instrumenting Sidekiq with Rails version < 4.2.
   module SidekiqInstrumentation
 
     class Middleware


### PR DESCRIPTION
Removes a bunch of version negotiation used for rails 2 - 5.1 support. These paths are no longer exercised by testing and complicate maintenance. Previous versions of marginalia can still be used for compatibility.