### PR TITLE
Avoid generating warnings

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -76,7 +76,6 @@ module Marginalia
       options[:prepare] ||= false
       exec_query_without_marginalia(annotate_sql(sql), *args, **options)
     end
-    ruby2_keywords :exec_query_with_marginalia if respond_to?(:ruby2_keywords, true)
 
     def exec_delete_with_marginalia(sql, *args)
       exec_delete_without_marginalia(annotate_sql(sql), *args)


### PR DESCRIPTION
This method accepts keywords natively and so doesn't need the ruby2_keywords helper. Using the helper here causes noisy warnings. It was introduced in a refactor in #125.

https://github.com/basecamp/marginalia/commit/3dc38461ed500a469687a9eb23594fa82f3b8d19#commitcomment-54940321

> This causes a warning:
> ```
> warning: Skipping set of ruby2_keywords flag for exec_query_with_marginalia (method accepts keywords or method does not accept argument splat)
> ```
>
> I guess it's harmless but would be good to eliminate it if possible