### PR TITLE
CI: add Ruby 3.1 and 3.2 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       DB_HOST: 127.0.0.1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
         rails-version: ["5.2.0", "6.0.0", "6.1.0"]
         exclude:
           # Rails 5.2 does not support Ruby 3.0
           - {ruby-version: "3.0", rails-version: "5.2.0"}
+          - {ruby-version: "3.1", rails-version: "5.2.0"}
+          - {ruby-version: "3.2", rails-version: "5.2.0"}
 
     services:
       mysql:


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the build matrix along with Ruby 3.1. 