### PR TITLE
Only interact with ActionController::API on load

### DIFF
--- a/lib/marginalia/railtie.rb
+++ b/lib/marginalia/railtie.rb
@@ -40,7 +40,7 @@ module Marginalia
 
     def self.insert_into_action_controller
       ActionController::Base.send(:include, ActionControllerInstrumentation)
-      if defined? ActionController::API
+      ActiveSupport.on_load :action_controller_api do
         ActionController::API.send(:include, ActionControllerInstrumentation)
       end
     end


### PR DESCRIPTION
Fixes this

```
:action_controller_api was loaded before application initialization.
Prematurely executing load hooks will slow down your boot time
and could cause conflicts with the load order of your application.
Please wrap your code with an on_load hook:

  ActiveSupport.on_load(:action_controller_api) do
    # your code here
  end


Called from:
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/activesupport/lib/active_support/lazy_load_hooks.rb:97:in 'Module#class_eval'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/activesupport/lib/active_support/lazy_load_hooks.rb:97:in 'block in ActiveSupport::LazyLoadHooks#execute_hook'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/activesupport/lib/active_support/lazy_load_hooks.rb:87:in 'ActiveSupport::LazyLoadHooks#with_execution_control'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/activesupport/lib/active_support/lazy_load_hooks.rb:92:in 'ActiveSupport::LazyLoadHooks#execute_hook'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/activesupport/lib/active_support/lazy_load_hooks.rb:78:in 'block in ActiveSupport::LazyLoadHooks#run_load_hooks'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/activesupport/lib/active_support/lazy_load_hooks.rb:77:in 'Array#each'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/activesupport/lib/active_support/lazy_load_hooks.rb:77:in 'ActiveSupport::LazyLoadHooks#run_load_hooks'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/actionpack/lib/action_controller/api.rb:153:in '<class:API>'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/actionpack/lib/action_controller/api.rb:93:in '<module:ActionController>'
ruby/3.4.0/bundler/gems/rails-0e53474dd25b/actionpack/lib/action_controller/api.rb:10:in '<main>'
/usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
/usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
ruby/3.4.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
ruby/3.4.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in 'Kernel#require'
ruby/3.4.0/gems/marginalia-1.11.1/lib/marginalia/railtie.rb:44:in 'Marginalia::Railtie.insert_into_action_controller'
ruby/3.4.0/gems/marginalia-1.11.1/lib/marginalia/railtie.rb:12:in 'block (2 levels) in <class:Railtie>'
```